### PR TITLE
fix: Correct taskmaster JSON syntax error

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -613,7 +613,6 @@
       "created": "2025-10-19T13:01:09.207Z",
       "description": "Tasks for master context",
       "updated": "2025-10-19T18:22:57.320Z"
-      "updated": "2025-10-19T16:02:39.669Z"
     }
   }
 }


### PR DESCRIPTION
## Fix\nCorrects duplicate 'updated' key in tasks.json that was causing task-master commands to fail.\n\n### Changes\n- Removed duplicate 'updated' key in tasks.json metadata\n- Fixed JSON parsing error\n\n### Why this was needed\n- Task-master list command was failing with 'Failed to get task list'\n- JSON file had two 'updated' keys in metadata section