### PR TITLE
fix: Remove duplicate 'updated' key in tasks.json

### DIFF
--- a/.taskmaster/tasks/tasks.json
+++ b/.taskmaster/tasks/tasks.json
@@ -614,7 +614,6 @@
       "created": "2025-10-19T13:01:09.207Z",
       "description": "Tasks for master context",
       "updated": "2025-10-19T18:17:11.088Z"
-      "updated": "2025-10-19T16:02:39.669Z"
     }
   }
 }


### PR DESCRIPTION
## Fix\nRemoves duplicate 'updated' key in tasks.json metadata that was causing Task Master commands to fail.\n\n### Changes\n- Fixed JSON syntax error by removing duplicate 'updated' key\n- Task Master commands now work correctly\n\n### Why this was needed\n- Task Master was failing with 'No valid tasks found' error\n- JSON file had duplicate keys in metadata section\n- This fix allows proper task management workflow