### PR TITLE
docs(kb): introduce local error-fix knowledge base and consult-first rule

### DIFF
--- a/.cursor/kb/entries/mypy-missing-return-annotation.md
+++ b/.cursor/kb/entries/mypy-missing-return-annotation.md
@@ -1,0 +1,46 @@
+---
+id: mypy-missing-return-annotation
+title: MyPy - Function missing return type annotation
+tags: [mypy, types]
+owner: maintainers
+createdAt: 2025-10-28
+updatedAt: 2025-10-28
+resolutionLevel: approved
+appliesTo:
+  paths: ["src/**/*.py", "tests/**/*.py"]
+  tools: ["mypy"]
+patterns:
+  - "error: Function is missing a type annotation for return value"
+  - "Missing return type annotation"
+links:
+  taskmaster: []
+  prs: []
+  commits: []
+---
+
+## Symptoms
+- MyPy reports a function or method without explicit return type annotation.
+
+## Root Cause
+- Missing `-> ReturnType` in the function signature.
+
+## Standard Resolution
+1. Add an explicit return type to the function signature:
+   - Example: `def load_config(path: str) -> dict[str, Any]: ...`
+2. Prefer concrete types (e.g., `dict[str, Any]`, `list[Item]`) over `Any`.
+3. For async functions, annotate with `-> T` (not `Coroutine`) unless low-level.
+4. If function returns `None`, annotate `-> None`.
+5. If the function is intentionally dynamic, add precise `typing` aliases or `Protocol`.
+
+## Code Diff Guidance
+- Update signatures only; avoid adding runtime casts just to satisfy types.
+- If needed, add imports from `typing` (e.g., `from typing import Any, Optional, Protocol`).
+
+## Validation
+- Run:
+  - `mypy src/crypto_bot`
+- Ensure no MyPy errors remain for the function.
+
+## Notes
+- Align with `pyproject.toml` MyPy settings (strict equality, no implicit optional, etc.).
+

--- a/.cursor/kb/entries/ruff-f401-unused-import.md
+++ b/.cursor/kb/entries/ruff-f401-unused-import.md
@@ -1,0 +1,47 @@
+---
+id: ruff-f401-unused-import
+title: Ruff F401 - unused import
+tags: [ruff, lint, imports]
+owner: maintainers
+createdAt: 2025-10-28
+updatedAt: 2025-10-28
+resolutionLevel: approved
+appliesTo:
+  paths: ["**/*.py"]
+  tools: ["ruff"]
+patterns:
+  - "F401\\b.*unused import"
+  - "unused import\\b"
+links:
+  taskmaster: []
+  prs: []
+  commits: []
+---
+
+## Symptoms
+- Ruff reports `F401: <name> imported but unused`.
+
+## Root Cause
+- Symbol imported but not referenced in the module. Often leftover from refactors or re-exports not needed.
+
+## Standard Resolution
+1. Remove the unused import line.
+2. If the import is needed for side-effects or public API exposure, add `# noqa: F401` with a comment explaining why, or prefer an explicit `__all__` export pattern.
+3. For tests, consider narrowing imports to the specific used symbols.
+
+## Code Diff Guidance
+- Remove lines like:
+  - `from x import y  # unused`
+  - `import x  # unused`
+- If side-effect is required, prefer:
+  - Add a short comment: `# required side-effect (register signals)` and optionally `# noqa: F401`.
+
+## Validation
+- Run:
+  - `ruff check --config=pyproject.toml .`
+- Ensure no F401 remains.
+
+## Notes
+- Avoid blanket `noqa` unless justified.
+- Prefer keeping imports close to usage sites.
+

--- a/.cursor/kb/index.json
+++ b/.cursor/kb/index.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id": "ruff-f401-unused-import",
+    "title": "Ruff F401: unused import",
+    "tags": ["ruff", "lint", "imports"],
+    "status": "approved",
+    "patterns": [
+      "F401\\b.*unused import",
+      "unused import\\b"
+    ],
+    "entry": ".cursor/kb/entries/ruff-f401-unused-import.md",
+    "appliesTo": {
+      "paths": ["**/*.py"],
+      "tools": ["ruff"]
+    }
+  },
+  {
+    "id": "mypy-missing-return-annotation",
+    "title": "MyPy: Function missing return type annotation",
+    "tags": ["mypy", "types"],
+    "status": "approved",
+    "patterns": [
+      "error: Function is missing a type annotation for return value",
+      "Missing return type annotation"
+    ],
+    "entry": ".cursor/kb/entries/mypy-missing-return-annotation.md",
+    "appliesTo": {
+      "paths": ["src/**/*.py", "tests/**/*.py"],
+      "tools": ["mypy"]
+    }
+  }
+]
+

--- a/.cursor/rules/knowledge_base.mdc
+++ b/.cursor/rules/knowledge_base.mdc
@@ -1,0 +1,34 @@
+---
+description: Enforce consult-first behavior with local KB of errors and standardized fixes
+globs: **/*
+alwaysApply: true
+---
+
+# 🧠 Local Knowledge Base - Consult First
+
+## Purpose
+Ensure agents consult the local knowledge base before proposing fixes for lint/type/test/build errors, applying standardized resolutions and improving consistency.
+
+## Behavior
+- BEFORE making fixes, search `.cursor/kb/index.json` using the current error text/logs.
+- Match by `patterns` (regex) and `tags`. If a match is found:
+  - Apply the "Standard Resolution" from the linked entry.
+  - If the resolution conflicts with project norms, ask for confirmation before proceeding.
+- AFTER applying a fix:
+  - Append validation notes and links via Taskmaster `update_subtask` where applicable.
+  - Reference the KB entry ID in commit/PR descriptions when relevant.
+- If NO match:
+  - Propose a new KB entry draft using `.cursor/templates/kb_entry.md`.
+  - Include a short Context7 research summary (if used) and link the related Taskmaster subtask.
+
+## Matching Guidance
+- Prefer strict regex for tools (Ruff/MyPy/Pytest) and fallback to generic error text.
+- Consider file paths and tool names from `appliesTo` to increase precision.
+
+## Validation
+- Run the relevant quality gates (Ruff/MyPy/Pytest) after applying the fix.
+- Ensure no new warnings are introduced.
+
+## Governance
+- Use `resolutionLevel: experimental` for new entries; promote to `approved` after 2+ verified uses.
+- Update `updatedAt` and keep links (Taskmaster IDs, PRs, commits) current.

--- a/.cursor/templates/kb_entry.md
+++ b/.cursor/templates/kb_entry.md
@@ -1,0 +1,37 @@
+---
+id: <unique-id>
+title: <short-title>
+tags: [tool, category]
+owner: <maintainer>
+createdAt: <YYYY-MM-DD>
+updatedAt: <YYYY-MM-DD>
+resolutionLevel: experimental
+appliesTo:
+  paths: ["**/*.py"]
+  tools: ["ruff", "mypy", "pytest"]
+patterns:
+  - "<regex capturing error text>"
+links:
+  taskmaster: ["<task-id>"]
+  prs: ["<url>"]
+  commits: ["<sha>"]
+---
+
+## Symptoms
+- <error messages or stack traces>
+
+## Root Cause
+- <concise diagnosis>
+
+## Standard Resolution
+1. <step-by-step resolution>
+
+## Code Diff Guidance
+- <concise guidance; avoid long blobs>
+
+## Validation
+- Run commands to verify (e.g., ruff/mypy/pytest)
+
+## Notes
+- Security/Performance caveats
+


### PR DESCRIPTION
This PR introduces a local AI knowledge base for recurring errors and standardized fixes, plus a Cursor rule to enforce consult-first behavior.\n\nAdds:\n- .cursor/kb/index.json with initial mappings\n- .cursor/kb/entries (Ruff F401, MyPy missing return type)\n- .cursor/templates/kb_entry.md template\n- .cursor/rules/knowledge_base.mdc\n\nWorkflow:\n- Agents consult KB first, apply approved Standard Resolution, log findings via Taskmaster\n- Propose new KB entries when no match; include Context7 summary and task links\n\nOptional next steps:\n- Local MCP server (kb.search/kb.add)\n- CI hints that surface KB suggestions on failures