### PR TITLE
feat(plugins): add MACD indicator with configurable parameters [Task #10]

### DIFF
--- a/src/crypto_bot/plugins/indicators/__init__.py
+++ b/src/crypto_bot/plugins/indicators/__init__.py
@@ -13,6 +13,7 @@ from crypto_bot.plugins.indicators.loader import (
 )
 from crypto_bot.plugins.indicators.pandas_ta_indicators import (
     EMAIndicator,
+    MACDIndicator,
     RSIIndicator,
     SMAIndicator,
 )
@@ -29,4 +30,5 @@ __all__ = [
     "RSIIndicator",
     "EMAIndicator",
     "SMAIndicator",
+    "MACDIndicator",
 ]

--- a/tests/unit/plugins/test_pandas_ta_indicators.py
+++ b/tests/unit/plugins/test_pandas_ta_indicators.py
@@ -7,6 +7,7 @@ from crypto_bot.plugins.indicators.base import InvalidIndicatorParameters
 from crypto_bot.plugins.indicators.cache import IndicatorCache, get_cache
 from crypto_bot.plugins.indicators.pandas_ta_indicators import (
     EMAIndicator,
+    MACDIndicator,
     RSIIndicator,
     SMAIndicator,
 )
@@ -312,3 +313,263 @@ class TestSMAIndicator:
 
         assert cache._hits > 0
         pd.testing.assert_series_equal(result1, result2)
+
+
+class TestMACDIndicator:
+    """Tests for MACDIndicator."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        get_cache().clear()
+
+    def test_metadata(self) -> None:
+        """Test indicator metadata."""
+        indicator = MACDIndicator()
+        assert indicator.metadata.name == "macd"
+        assert indicator.metadata.version == "1.0"
+        assert "momentum" in indicator.metadata.description.lower()
+
+    def test_validate_parameters_valid(self) -> None:
+        """Test parameter validation with valid parameters."""
+        indicator = MACDIndicator()
+        indicator.validate_parameters({"fast": 12, "slow": 26, "signal": 9})
+        indicator.validate_parameters({"fast": 8, "slow": 21, "signal": 5})
+        # Test defaults
+        indicator.validate_parameters({})
+
+    def test_validate_parameters_invalid(self) -> None:
+        """Test parameter validation with invalid parameters."""
+        indicator = MACDIndicator()
+
+        with pytest.raises(InvalidIndicatorParameters):
+            indicator.validate_parameters({"fast": -1})
+
+        with pytest.raises(InvalidIndicatorParameters):
+            indicator.validate_parameters({"slow": 0})
+
+        with pytest.raises(InvalidIndicatorParameters):
+            indicator.validate_parameters({"signal": "9"})  # type: ignore[arg-type]
+
+        with pytest.raises(InvalidIndicatorParameters):
+            indicator.validate_parameters({"fast": 26, "slow": 12})  # fast >= slow
+
+        with pytest.raises(InvalidIndicatorParameters):
+            indicator.validate_parameters({"fast": 12, "slow": 12})  # fast == slow
+
+    def test_calculate_macd_default_parameters(self) -> None:
+        """Test MACD calculation with default parameters."""
+        indicator = MACDIndicator()
+        # Need sufficient data for MACD (at least slow period + signal period)
+        data = pd.DataFrame(
+            {
+                "close": [
+                    100,
+                    102,
+                    101,
+                    105,
+                    107,
+                    106,
+                    108,
+                    110,
+                    109,
+                    111,
+                    112,
+                    111,
+                    113,
+                    115,
+                    114,
+                    116,
+                    118,
+                    117,
+                    120,
+                    122,
+                    121,
+                    123,
+                    125,
+                    124,
+                    126,
+                    128,
+                    127,
+                    129,
+                    131,
+                    130,
+                    132,
+                    134,
+                    133,
+                    135,
+                    137,
+                    136,
+                ]
+            }
+        )
+
+        result = indicator.calculate(data, {})
+
+        assert isinstance(result, pd.DataFrame)
+        # Should have 3 columns: MACD line, signal line, histogram
+        assert len(result.columns) == 3
+        # Check column names follow standard convention
+        assert any("MACD_" in col for col in result.columns)
+        assert any("MACDs_" in col for col in result.columns)
+        assert any("MACDh_" in col for col in result.columns)
+        assert len(result) == len(data)
+        # Should have some valid values after warm-up period
+        assert result.notna().any().any()
+
+    def test_calculate_macd_custom_parameters(self) -> None:
+        """Test MACD calculation with custom parameters."""
+        indicator = MACDIndicator()
+        data = pd.DataFrame(
+            {
+                "close": [
+                    100,
+                    102,
+                    101,
+                    105,
+                    107,
+                    106,
+                    108,
+                    110,
+                    109,
+                    111,
+                    112,
+                    111,
+                    113,
+                    115,
+                    114,
+                    116,
+                    118,
+                    117,
+                    120,
+                    122,
+                    121,
+                    123,
+                    125,
+                    124,
+                    126,
+                ]
+            }
+        )
+
+        result = indicator.calculate(data, {"fast": 8, "slow": 21, "signal": 5})
+
+        assert isinstance(result, pd.DataFrame)
+        assert len(result.columns) == 3
+        # Check that custom parameters are reflected in column names
+        assert any("8" in col and "21" in col and "5" in col for col in result.columns)
+
+    def test_calculate_macd_missing_close(self) -> None:
+        """Test MACD calculation with missing close column."""
+        indicator = MACDIndicator()
+        data = pd.DataFrame({"open": [100, 101, 102]})
+
+        with pytest.raises(ValueError, match="MACD requires 'close' column"):
+            indicator.calculate(data, {"fast": 12, "slow": 26, "signal": 9})
+
+    def test_calculate_macd_caching(self) -> None:
+        """Test that MACD results are cached."""
+        cache = get_cache()
+        indicator = MACDIndicator()
+        data = pd.DataFrame(
+            {
+                "close": [
+                    100,
+                    102,
+                    101,
+                    105,
+                    107,
+                    106,
+                    108,
+                    110,
+                    109,
+                    111,
+                    112,
+                    111,
+                    113,
+                    115,
+                    114,
+                    116,
+                    118,
+                    117,
+                    120,
+                    122,
+                    121,
+                    123,
+                    125,
+                    124,
+                    126,
+                    128,
+                    127,
+                    129,
+                    131,
+                    130,
+                    132,
+                    134,
+                    133,
+                    135,
+                    137,
+                    136,
+                ]
+            }
+        )
+        params = {"fast": 12, "slow": 26, "signal": 9}
+
+        result1 = indicator.calculate(data, params)
+        result2 = indicator.calculate(data, params)
+
+        assert cache._hits > 0
+        pd.testing.assert_frame_equal(result1, result2)
+
+    def test_macd_components(self) -> None:
+        """Test that MACD returns all three components."""
+        indicator = MACDIndicator()
+        data = pd.DataFrame(
+            {
+                "close": [
+                    100,
+                    102,
+                    101,
+                    105,
+                    107,
+                    106,
+                    108,
+                    110,
+                    109,
+                    111,
+                    112,
+                    111,
+                    113,
+                    115,
+                    114,
+                    116,
+                    118,
+                    117,
+                    120,
+                    122,
+                    121,
+                    123,
+                    125,
+                    124,
+                    126,
+                    128,
+                    127,
+                    129,
+                    131,
+                    130,
+                    132,
+                    134,
+                    133,
+                    135,
+                    137,
+                    136,
+                ]
+            }
+        )
+
+        result = indicator.calculate(data, {})
+
+        # Should have exactly 3 columns
+        assert len(result.columns) == 3
+        # All columns should have same length as input
+        for col in result.columns:
+            assert len(result[col]) == len(data)


### PR DESCRIPTION
# 📋 Pull Request

## 📝 Descrição
Adiciona indicador MACD (Moving Average Convergence Divergence) ao sistema de plugins de indicadores técnicos. RSI e EMA já estavam implementados na tarefa #9 com parâmetros configuráveis.

### Componentes Implementados:
- ✅ MACDIndicator com parâmetros configuráveis (fast, slow, signal)
- ✅ Validação completa de parâmetros (fast < slow)
- ✅ Integração com pandas-ta com fallback para pandas
- ✅ Retorna DataFrame com 3 componentes: MACD line, signal line, histogram
- ✅ Cache LRU integrado
- ✅ 8 novos testes unitários (todos passando)

## 🔗 Issues Relacionadas
Implements task #10: Indicator Plugins: RSI, MACD, EMA

**Nota:** RSI e EMA já estavam implementados na task #9 com parâmetros configuráveis completos.

## 🎯 Tipo de Mudança
- [x] ✨ Nova feature (mudança que adiciona funcionalidade)
- [x] 🧪 Testes (adição ou correção de testes)

## 🧪 Como Testar
1. Executar testes: `pytest tests/unit/plugins/test_pandas_ta_indicators.py::TestMACDIndicator -v`
2. Exemplo de uso:
```python
from crypto_bot.plugins.indicators import MACDIndicator
import pandas as pd

# Usar indicador diretamente
indicator = MACDIndicator()
data = pd.DataFrame({"close": [100, 102, 101, 105, 107, ...]})

# Default: fast=12, slow=26, signal=9
macd_default = indicator.calculate(data, {})

# Custom parameters
macd_custom = indicator.calculate(data, {"fast": 8, "slow": 21, "signal": 5})

# Resultado é DataFrame com 3 colunas:
# - MACD line
# - Signal line  
# - Histogram
```

## 📋 Checklist
- [x] ✅ Meu código segue as diretrizes de estilo do projeto
- [x] ✅ Realizei uma auto-revisão do meu código
- [x] ✅ Comentei partes do código difíceis de entender
- [x] ✅ Minhas mudanças não geram warnings
- [x] ✅ Adicionei testes que provam que minha correção é eficaz ou que minha feature funciona
- [x] ✅ Testes novos e existentes passam localmente (25 testes passando)
- [x] ✅ Qualquer mudança dependente foi mergeada e publicada

## 📊 Performance
- [x] ✅ Otimizações de performance implementadas (cache LRU para evitar recálculos)
- [x] ✅ Testes de performance executados (cache hit/miss tracking)

## 📚 Documentação
- [x] ✅ Adicionei comentários no código (docstrings completos)
- [x] ✅ Documentação inline para todas as classes e métodos públicos

## 🔒 Segurança
- [x] ✅ Não expõe credenciais ou dados sensíveis
- [x] ✅ Valida todas as entradas do usuário (validação de parâmetros)
- [x] ✅ Não introduz vulnerabilidades conhecidas

## 🔄 Breaking Changes
- [x] ✅ Não há breaking changes

## 📝 Notas Adicionais
- MACD retorna DataFrame (ao invés de Series) porque contém 3 componentes distintos
- Validação garante que fast < slow (constraint do indicador MACD)
- Fallback automático para implementação pandas quando pandas-ta não disponível
- Todos os hooks de pre-commit passando (ruff, black, mypy, pytest, bandit)
- Total de testes: 43 (18 base/cache + 25 indicadores)