### PR TITLE
[Task #11] Plugin System - Strategy Interface & Loader

### DIFF
--- a/docs/architecture/strategy_plugins.md
+++ b/docs/architecture/strategy_plugins.md
@@ -1,0 +1,55 @@
+# Estratégias como Plugins
+
+Este documento descreve como o bot descobre e carrega estratégias de trading via Entry Points do Python.
+
+## Interface Base
+
+- Arquivo: `src/crypto_bot/plugins/strategies/base.py`
+- Classe ABC: `Strategy`
+  - `name: ClassVar[str]` — identificador único da estratégia
+  - `validate_parameters(params)` — valida parâmetros
+  - `generate_signal(market_data, params) -> StrategySignal` — gera sinal padronizado
+  - `reset_state()` — reinicializa estado interno
+- DTO: `StrategySignal` (action, strength, metadata)
+
+## Descoberta de Plugins
+
+- Arquivo: `src/crypto_bot/plugins/strategies/loader.py`
+- Grupo de entry points: `crypto_bot.strategies`
+- Função principal: `discover_strategies() -> Mapping[str, Type[Strategy]]`
+  - Usa `importlib.metadata.entry_points(group=...)`
+  - Valida subclasses de `Strategy`
+  - Previne nomes duplicados (primeiro registro vence)
+  - Cache com `functools.lru_cache(maxsize=1)`
+  - Log estruturado dos eventos de descoberta/erros
+
+## Como Registrar um Plugin Externo
+
+No pacote da sua estratégia (instalado no mesmo ambiente), adicione no `pyproject.toml`:
+
+```toml
+[project.entry-points."crypto_bot.strategies"]
+minha_estrategia = "meu_pacote.minha_mod:MinhaClasseEstrategia"
+```
+
+A classe referenciada deve herdar de `Strategy` e definir `name`.
+
+## Fallback
+
+Se nenhum plugin for encontrado, `discover_strategies()` retorna um mapeamento vazio e o sistema continua operando sem crash, registrando avisos de log.
+
+## Boas Práticas
+
+- Evite `pkg_resources`; prefira `importlib.metadata`
+- Valide interface antes de registrar (segurança e tipagem)
+- Trate exceções por plugin isoladamente
+- Utilize logs estruturados para auditoria e debug
+
+## Testes
+
+- Testes unitários em `tests/unit/plugins/test_strategy_loader.py` cobrem:
+  - descoberta de plugins válidos
+  - ignorar não-subclasses
+  - nomes duplicados
+  - falhas de carregamento
+  - cenário sem plugins

--- a/src/crypto_bot/plugins/indicators/cache.py
+++ b/src/crypto_bot/plugins/indicators/cache.py
@@ -219,7 +219,7 @@ def cached_indicator(
         cache = get_cache()
 
     def decorator(
-        func: Callable[..., pd.Series | pd.DataFrame]
+        func: Callable[..., pd.Series | pd.DataFrame],
     ) -> Callable[..., pd.Series | pd.DataFrame]:
         def wrapper(
             data: pd.DataFrame, params: Mapping[str, Any]

--- a/src/crypto_bot/plugins/strategies/base.py
+++ b/src/crypto_bot/plugins/strategies/base.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Mapping, MutableMapping
+
+
+@dataclass(slots=True)
+class StrategySignal:
+    """
+    Representa um sinal gerado por uma estratégia.
+
+    Attributes:
+        action: Ação recomendada (por exemplo: "buy", "sell", "hold").
+        strength: Força/confiança do sinal, tipicamente em [0.0, 1.0].
+        metadata: Informações adicionais relevantes para auditoria/explicabilidade.
+    """
+
+    action: str
+    strength: float = 0.0
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+
+
+class Strategy(ABC):
+    """
+    Interface base para estratégias de trading plugáveis.
+
+    Requisitos para implementações concretas:
+    - Definir `name` como identificador único e estável da estratégia.
+    - Validar parâmetros de configuração recebidos.
+    - Gerar sinais a partir de dados de mercado e parâmetros.
+    - Gerenciar e reinicializar estado interno quando necessário.
+    """
+
+    name: ClassVar[str]
+
+    @abstractmethod
+    def validate_parameters(self, params: Mapping[str, Any]) -> None:
+        """
+        Valida os parâmetros fornecidos para a estratégia.
+
+        Args:
+            params: Mapeamento de parâmetros de configuração.
+
+        Raises:
+            ValueError: Quando parâmetros obrigatórios estão ausentes ou inválidos.
+            TypeError: Quando tipos de parâmetros não correspondem ao esperado.
+        """
+
+    @abstractmethod
+    def generate_signal(
+        self, market_data: Any, params: Mapping[str, Any]
+    ) -> StrategySignal:
+        """
+        Gera um `StrategySignal` a partir dos dados de mercado e parâmetros.
+
+        Args:
+            market_data: Estrutura com dados de mercado (ex.: candles, indicadores, etc.).
+            params: Mapeamento de parâmetros validados.
+
+        Returns:
+            StrategySignal: Sinal de trading padronizado.
+        """
+
+    @abstractmethod
+    def reset_state(self) -> None:
+        """
+        Reinicializa qualquer estado interno mantido pela estratégia.
+        """

--- a/src/crypto_bot/plugins/strategies/loader.py
+++ b/src/crypto_bot/plugins/strategies/loader.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from importlib.metadata import EntryPoint, entry_points
+from typing import Dict, Iterable, Mapping, Type
+
+from crypto_bot.utils.structured_logger import get_logger
+
+from .base import Strategy
+
+# Grupo de entry points para estratégias externas
+ENTRY_POINT_GROUP: str = "crypto_bot.strategies"
+
+
+@lru_cache(maxsize=1)
+def discover_strategies() -> Mapping[str, Type[Strategy]]:
+    """
+    Descobre e valida estratégias registradas via Entry Points.
+
+    Returns:
+        Mapping de `name` -> classe `Strategy`.
+
+    Observações:
+    - Apenas classes que são subclasses de `Strategy` serão registradas.
+    - Estratégias com nomes duplicados serão ignoradas após o primeiro registro.
+    - Falhas ao carregar um entry point são ignoradas para não interromper a descoberta.
+    """
+
+    logger = get_logger(__name__)
+    logger.info("discover_strategies:start", entry_point_group=ENTRY_POINT_GROUP)
+
+    discovered: Dict[str, Type[Strategy]] = {}
+
+    try:
+        eps_iter: Iterable[EntryPoint] = entry_points(group=ENTRY_POINT_GROUP)
+    except TypeError:
+        # Compatibilidade defensiva para ambientes antigos (API de entrada sem argumentos)
+        all_eps = entry_points()
+        selector = getattr(all_eps, "select", None)
+        eps_iter = selector(group=ENTRY_POINT_GROUP) if callable(selector) else []
+
+    eps_list = list(eps_iter)
+    logger.debug(
+        "discover_strategies:entry_points_fetched",
+        count=len(eps_list),
+    )
+
+    for ep in eps_list:
+        try:
+            loaded = ep.load()
+        except Exception as exc:
+            logger.warning(
+                "discover_strategies:load_failed",
+                entry_point=str(getattr(ep, "value", ep)),
+                exc_type=type(exc).__name__,
+            )
+            continue
+
+        # Suportar tanto classe Strategy quanto fábrica que retorna classe Strategy
+        candidate = loaded
+        try:
+            # Se for uma fábrica zero-arg que retorna a classe
+            if not isinstance(candidate, type) and callable(candidate):
+                candidate = candidate()
+        except Exception as exc:
+            logger.warning(
+                "discover_strategies:factory_failed",
+                entry_point=str(getattr(ep, "value", ep)),
+                exc_type=type(exc).__name__,
+            )
+            continue
+
+        if not isinstance(candidate, type):
+            logger.warning(
+                "discover_strategies:invalid_type",
+                entry_point=str(getattr(ep, "value", ep)),
+            )
+            continue
+        if not issubclass(candidate, Strategy):
+            logger.warning(
+                "discover_strategies:not_subclass",
+                candidate=getattr(candidate, "__name__", str(candidate)),
+            )
+            continue
+
+        # Verifica atributo `name` definido na classe
+        strategy_name = getattr(candidate, "name", None)
+        if not isinstance(strategy_name, str) or not strategy_name:
+            logger.warning(
+                "discover_strategies:missing_name",
+                candidate=getattr(candidate, "__name__", str(candidate)),
+            )
+            continue
+
+        if strategy_name in discovered:
+            # Duplicata: manter o primeiro registro
+            logger.warning("discover_strategies:duplicate_name", name=strategy_name)
+            continue
+
+        discovered[strategy_name] = candidate
+        logger.info(
+            "discover_strategies:registered", name=strategy_name, cls=candidate.__name__
+        )
+
+    logger.info("discover_strategies:done", registered=list(discovered.keys()))
+    return discovered

--- a/tests/unit/plugins/test_strategy_loader.py
+++ b/tests/unit/plugins/test_strategy_loader.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from importlib.metadata import EntryPoint
+from typing import Any, Mapping
+
+import pytest
+
+from crypto_bot.plugins.strategies.base import Strategy, StrategySignal
+from crypto_bot.plugins.strategies.loader import (
+    ENTRY_POINT_GROUP,
+    discover_strategies,
+)
+
+
+class ValidStrategy(Strategy):
+    name = "valid"
+
+    def validate_parameters(
+        self, params: Mapping[str, Any]
+    ) -> None:  # pragma: no cover - trivial
+        return None
+
+    def generate_signal(
+        self, market_data: Any, params: Mapping[str, Any]
+    ) -> StrategySignal:
+        return StrategySignal(action="hold", strength=0.0)
+
+    def reset_state(self) -> None:  # pragma: no cover - trivial
+        return None
+
+
+class AnotherValid(Strategy):
+    name = "valid"  # duplicate name on purpose
+
+    def validate_parameters(
+        self, params: Mapping[str, Any]
+    ) -> None:  # pragma: no cover - trivial
+        return None
+
+    def generate_signal(
+        self, market_data: Any, params: Mapping[str, Any]
+    ) -> StrategySignal:
+        return StrategySignal(action="sell", strength=1.0)
+
+    def reset_state(self) -> None:  # pragma: no cover - trivial
+        return None
+
+
+class NotAStrategy:  # missing Strategy inheritance
+    pass
+
+
+def make_ep(name: str, value: str) -> EntryPoint:
+    return EntryPoint(name=name, value=value, group=ENTRY_POINT_GROUP)
+
+
+def clear_cache() -> None:
+    # Reset cache between tests
+    discover_strategies.cache_clear()  # type: ignore[attr-defined]
+
+
+def test_discover_returns_valid_strategy(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_cache()
+
+    eps = [
+        make_ep(
+            name="valid",
+            value="tests.unit.plugins.test_strategy_loader:ValidStrategy",
+        )
+    ]
+
+    monkeypatch.setattr(
+        "crypto_bot.plugins.strategies.loader.entry_points", lambda **kwargs: eps
+    )
+
+    result = discover_strategies()
+    assert "valid" in result
+    assert result["valid"].__name__ == "ValidStrategy"
+
+
+def test_discover_ignores_non_subclass(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_cache()
+
+    eps = [
+        make_ep(
+            name="not_strategy",
+            value="tests.unit.plugins.test_strategy_loader:NotAStrategy",
+        )
+    ]
+
+    monkeypatch.setattr(
+        "crypto_bot.plugins.strategies.loader.entry_points", lambda **kwargs: eps
+    )
+
+    result = discover_strategies()
+    assert result == {}
+
+
+def test_discover_handles_duplicate_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_cache()
+
+    eps = [
+        make_ep(
+            name="valid",
+            value="tests.unit.plugins.test_strategy_loader:ValidStrategy",
+        ),
+        make_ep(
+            name="duplicate",
+            value="tests.unit.plugins.test_strategy_loader:AnotherValid",
+        ),
+    ]
+
+    monkeypatch.setattr(
+        "crypto_bot.plugins.strategies.loader.entry_points", lambda **kwargs: eps
+    )
+
+    result = discover_strategies()
+    # first wins
+    assert set(result.keys()) == {"valid"}
+    assert result["valid"].__name__ == "ValidStrategy"
+
+
+def test_discover_handles_load_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_cache()
+
+    class BrokenEntryPoint(EntryPoint):
+        def load(self) -> Any:  # type: ignore[override]
+            raise RuntimeError("boom")
+
+    broken = BrokenEntryPoint(
+        name="broken",
+        value="tests.unit.plugins.test_strategy_loader:ValidStrategy",
+        group=ENTRY_POINT_GROUP,
+    )
+    eps = [broken]
+
+    monkeypatch.setattr(
+        "crypto_bot.plugins.strategies.loader.entry_points", lambda **kwargs: eps
+    )
+
+    result = discover_strategies()
+    assert result == {}
+
+
+def test_discover_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_cache()
+    monkeypatch.setattr(
+        "crypto_bot.plugins.strategies.loader.entry_points", lambda **kwargs: []
+    )
+    result = discover_strategies()
+    assert result == {}


### PR DESCRIPTION
Implementa sistema de plugins de estratégias.

Mudanças:
- Cria `Strategy` e `StrategySignal` em `src/crypto_bot/plugins/strategies/base.py`.
- Implementa discovery `discover_strategies()` via `importlib.metadata.entry_points` com cache e logs estruturados.
- Adiciona testes unitários (`tests/unit/plugins/test_strategy_loader.py`).
- Documenta em `docs/architecture/strategy_plugins.md`.

Qualidade:
- Black, Ruff, MyPy: OK
- Pytest (com cobertura) passou localmente

Task Master:
- Tarefa 11 concluída no tag `feature-task-11-strategy-interface-loader`.

Checklist (resumo):
- [x] Código formatado (Black)
- [x] Lint OK (Ruff)
- [x] Tipos OK (MyPy)
- [x] Testes passando
- [x] Doc atualizada
